### PR TITLE
Enforce userAgent on tagless request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+## Changelog
+
+### v0.0.2
+* BREAKING: Enforces a userAgent as an option to createTaglessRequest
+  - Ad Manager will not count impressions of pixels requested with a different user-agent than the one used to fire the tagless request. As such, you should include the userAgent you intend to fire the impression with.
+
+### v.0.0.1
+Introduces a `createTaglessRequest` function and relevant types for making calls to the Ad Manager tagless request endpoint.

--- a/lib/createTaglessRequest.test.ts
+++ b/lib/createTaglessRequest.test.ts
@@ -1,6 +1,7 @@
 import nock from "nock"
 import { assert } from "chai"
-import createTaglessRequest from "./createTaglessRequest"
+import { createTaglessRequest } from "../index"
+import { RequestOptions } from "./createTaglessRequest"
 
 const creative = `
   <script>
@@ -10,9 +11,10 @@ const creative = `
   </script>
 `
 
-function mockSuccess(parameters: Record<string, any>) {
+function mockSuccess(parameters: Record<string, any>, options: RequestOptions) {
   nock("https://securepubads.g.doubleclick.net")
     .get("/gampad/adx")
+    .matchHeader('user-agent', options.userAgent)
     .query(parameters)
     .reply(200, creative)
 }
@@ -27,8 +29,8 @@ describe("createTaglessRequest", () => {
         tile: 1,
       }
 
-      mockSuccess(parameters)
-      const response = await createTaglessRequest(parameters)
+      mockSuccess(parameters, {userAgent: 'myUserAgent'} )
+      const response = await createTaglessRequest(parameters, { userAgent: 'myUserAgent' })
       assert.equal(response.status, 200)
       assert.isOk(await response.text())
     })

--- a/lib/createTaglessRequest.ts
+++ b/lib/createTaglessRequest.ts
@@ -1,10 +1,28 @@
 import TaglessRequestParameters from "../types/taglessRequestParameters"
 import createQueryString from "./createQueryString"
 
+export interface RequestOptions {
+  userAgent: string
+}
+
 const BASE_URL = "https://securepubads.g.doubleclick.net/gampad/adx"
 
-function createTaglessRequest(parameters: TaglessRequestParameters) {
-  return fetch(`${BASE_URL}?${createQueryString(parameters)}`)
+/**
+ * @param parameters A map of TaglessRequestParameters
+ * @param userAgent The user-agent for which you intend to fire the impression pixel.
+ *
+ * Ad Manager will not count impressions of pixels requested with a different user-agent
+ * than the one used to fire the tagless request. As such, you should include the userAgent you intend
+ * to fire the impression with.
+ *
+ * @returns a tagless response
+ */
+function createTaglessRequest(parameters: TaglessRequestParameters, options: RequestOptions) {
+  return fetch(`${BASE_URL}?${createQueryString(parameters)}`, {
+    headers: {
+      'User-Agent': options.userAgent
+    }
+  })
 }
 
 export default createTaglessRequest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bustle/gam",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "scripts": {
     "build": "npx webpack",
     "eslint": "eslint --ext .ts,.js --cache .",


### PR DESCRIPTION
Ad Manager will not count impressions of pixels requested with a different user-agent than the one used to fire the tagless request. As such, you should include the userAgent you intend to fire the impression with in the tagless request.