### PR TITLE
Allow passing all headers

### DIFF
--- a/lib/createTaglessRequest.test.ts
+++ b/lib/createTaglessRequest.test.ts
@@ -14,7 +14,7 @@ const creative = `
 function mockSuccess(parameters: Record<string, any>, options: RequestOptions) {
   nock("https://securepubads.g.doubleclick.net")
     .get("/gampad/adx")
-    .matchHeader('user-agent', options.userAgent)
+    .matchHeader('user-agent', options.headers['User-Agent'])
     .query(parameters)
     .reply(200, creative)
 }
@@ -29,8 +29,8 @@ describe("createTaglessRequest", () => {
         tile: 1,
       }
 
-      mockSuccess(parameters, {userAgent: 'myUserAgent'} )
-      const response = await createTaglessRequest(parameters, { userAgent: 'myUserAgent' })
+      mockSuccess(parameters, { headers: { 'User-Agent': 'myUserAgent' }} )
+      const response = await createTaglessRequest(parameters, { headers: { 'User-Agent': 'myUserAgent' }})
       assert.equal(response.status, 200)
       assert.isOk(await response.text())
     })

--- a/lib/createTaglessRequest.ts
+++ b/lib/createTaglessRequest.ts
@@ -14,12 +14,8 @@ const BASE_URL = "https://securepubads.g.doubleclick.net/gampad/adx"
  *
  * @returns a tagless response
  */
-function createTaglessRequest(parameters: TaglessRequestParameters, { userAgent }: RequestOptions = {}) {
-  return fetch(`${BASE_URL}?${createQueryString(parameters)}`, {
-    headers: {
-      ...(userAgent && { 'User-Agent': userAgent })
-    }
-  })
+function createTaglessRequest(parameters: TaglessRequestParameters, { headers }: RequestOptions = {}) {
+  return fetch(`${BASE_URL}?${createQueryString(parameters)}`, { headers })
 }
 
 export default createTaglessRequest

--- a/types/requestOptions.d.ts
+++ b/types/requestOptions.d.ts
@@ -1,5 +1,5 @@
 interface RequestOptions {
-  userAgent?: string
+  headers?: Record<string, string>
 }
 
 export default RequestOptions


### PR DESCRIPTION
Rather than just limiting to user agent. Might need others like referrer, x-forwarded-for, etc.